### PR TITLE
Fix save file corruption

### DIFF
--- a/Assets/Source/Actions/Cards/Deck.cs
+++ b/Assets/Source/Actions/Cards/Deck.cs
@@ -99,7 +99,7 @@ namespace Cardificer
 
                 if (pathToCards.Count != deck.cards.Count)
                 {
-                    Debug.LogError("Save File Corrupted: Deck failed to load");
+                    SaveManager.AutosaveCorrupted("Cards in deck failed to load");
                     return;
                 }
 
@@ -109,10 +109,7 @@ namespace Cardificer
 
                 if (deck.drawableCards.Count + deck.inHandCards.Count + deck.discardedCards.Count != deck.cards.Count)
                 {
-                    Debug.LogError("Save File Corrupted: Hand state failed to load");
-                    deck.drawableCards.Clear();
-                    deck.inHandCards.Clear();
-                    deck.discardedCards.Clear();
+                    SaveManager.AutosaveCorrupted("Draw/Hand/Discard & Deck size mismatch");
                     return;
                 }
             }

--- a/Assets/Source/Player/PlayerController.cs
+++ b/Assets/Source/Player/PlayerController.cs
@@ -32,9 +32,16 @@ namespace Cardificer
             if (!SaveManager.autosaveExists) { return; }
 
             transform.position = SaveManager.savedPlayerPosition;
+            // TODO: There is a small probability that the player position is invalid and is not caught by the default save file corruption detection.
+
             Health health = GetComponent<Health>();
             health.maxHealth = health.maxHealth;
             health.currentHealth = SaveManager.savedPlayerHealth;
+            if (health.currentHealth > health.maxHealth || health.currentHealth <= 0)
+            {
+                SaveManager.AutosaveCorrupted("Invalid player health");
+                return;
+            }
         }
 
         /// <summary>

--- a/Assets/Source/ProceduralGeneration/FloorGenerator.cs
+++ b/Assets/Source/ProceduralGeneration/FloorGenerator.cs
@@ -99,11 +99,30 @@ namespace Cardificer
             int nextCardIndex = vistedRooms[0].z;
             foreach (Vector3Int vistedRoom in vistedRooms)
             {
+                if (vistedRoom.x >= map.mapSize.x || vistedRoom.y >= map.mapSize.y || map.map[vistedRoom.x, vistedRoom.y].room == null)
+                {
+                    SaveManager.AutosaveCorrupted("Invalid room index");
+                    return;
+                }
+
                 lastRoom.Exit();
                 lastRoom = map.map[vistedRoom.x, vistedRoom.y].room.GetComponent<Room>();
                 lastRoom.Generate(false);
+
+                if (nextCardIndex > vistedRoom.z)
+                {
+                    SaveManager.AutosaveCorrupted("Card index too small");
+                    return;
+                }
+
                 while (nextCardIndex < vistedRoom.z)
                 {
+                    if (nextCardIndex >= Deck.playerDeck.cards.Count || nextCardIndex < 0)
+                    {
+                        SaveManager.AutosaveCorrupted("Card index out of bounds");
+                        return;
+                    }
+
                     OnCardAdded(Deck.playerDeck.cards[nextCardIndex]);
                     nextCardIndex++;
                 }


### PR DESCRIPTION
Save files should now no longer load null cards if the engine is restarted after saving. It also is now impossible for corrupted or missing save files to cause issues aside from lost progress.

To test play the game and quit and replay after clearing rooms. While the game is not running, go to the AppData folder and screw with the save files in any way you can think of, deleting files, editing and inserting gibberish, removing lines, etc.